### PR TITLE
SupabaseとPiniaを統合してポケモンアプリケーションを構築中

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <NuxtRouteAnnouncer />
-    <NuxtWelcome />
+    <NuxtPage />
   </div>
 </template>

--- a/app/composables/useSupaPokemon.ts
+++ b/app/composables/useSupaPokemon.ts
@@ -1,0 +1,41 @@
+// app/composables/useSupaPokemon.ts
+import type { Database } from "@/types/supabase"
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+type Pokemon = Database['public']['Tables']['pokemon']['Row']
+
+declare module '#app' {
+  interface NuxtApp {
+    $supabase: SupabaseClient<Database>
+  }
+}
+
+export const usePokemon = () => {
+  const { $supabase } = useNuxtApp()
+
+  const getAllPokemon = async () => {
+    const { data, error } = await $supabase
+      .from('pokemon')
+      .select('id, name, sprite_url, types')
+      .order('id') 
+    
+    if (error) throw error
+    return data || []
+  }
+
+  const getPokemonById = async (id: number): Promise<Pokemon> => {
+    const { data, error } = await $supabase
+      .from('pokemon')
+      .select('*')
+      .eq('id', id)
+      .single()
+    
+    if (error) throw error
+    return data
+  }
+
+  return {
+    getAllPokemon,
+    getPokemonById
+  }
+}

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,0 +1,3 @@
+<template>
+  <p>hello</p>
+</template>

--- a/app/plugins/supabase.client.ts
+++ b/app/plugins/supabase.client.ts
@@ -1,0 +1,22 @@
+// supabase.client.ts
+import { createClient } from '@supabase/supabase-js'
+import type { Database } from '@/types/supabase'
+
+export default defineNuxtPlugin(() => {
+  const config = useRuntimeConfig()
+  
+  const supabaseUrl = config.public.supabaseUrl as string
+  const supabaseAnonKey = config.public.supabaseAnonKey as string
+  
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error('Supabase URL and Anon Key are required')
+  }
+  
+  const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey)
+
+  return {
+    provide: {
+      supabase
+    }
+  }
+})

--- a/app/types/supabase.ts
+++ b/app/types/supabase.ts
@@ -1,0 +1,51 @@
+export interface Database {
+  public: {
+    Tables: {
+      pokemon: {
+        Row: {
+          id: number
+          name: string
+          japanese_name: string | null
+          height: number
+          weight: number
+          sprite_url: string | null
+          types: string[]
+          stats: {
+            hp: number
+            attack: number
+            defense: number
+          }
+          created_at: string
+        }
+        Insert: {
+          id: number
+          name: string
+          japanese_name?: string | null
+          height: number
+          weight: number
+          sprite_url?: string | null
+          types: string[]
+          stats: {
+            hp: number
+            attack: number
+            defense: number
+          }
+        }
+        Update: {
+          id?: number
+          name?: string
+          japanese_name?: string | null
+          height?: number
+          weight?: number
+          sprite_url?: string | null
+          types?: string[]
+          stats?: {
+            hp: number
+            attack: number
+            defense: number
+          }
+        }
+      }
+    }
+  }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,14 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
-  devtools: { enabled: true }
+  devtools: { enabled: true },
+  modules: [
+    '@pinia/nuxt',
+  ],
+  runtimeConfig: {
+    public: {
+      supabaseUrl: process.env.SUPABASE_URL,
+      supabaseAnonKey: process.env.SUPABASE_ANON_KEY,
+    }
+  }
 })

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
+    "@pinia/nuxt": "^0.11.2",
+    "@supabase/supabase-js": "^2.56.1",
     "nuxt": "^4.0.3",
+    "pinia": "^3.0.3",
     "vue": "^3.5.20",
     "vue-router": "^4.5.1"
   }

--- a/server/api/secure-pokemon.get.ts
+++ b/server/api/secure-pokemon.get.ts
@@ -1,0 +1,8 @@
+import { usePokemon } from "@/composables/useSupaPokemon";
+
+const { getPokemonById } = usePokemon();
+
+export default defineEventHandler(async () => {
+  const result = await getPokemonById(1);
+  return result;
+})


### PR DESCRIPTION
# プロジェクト変更記録メモ

## 日付
2025-09-01

## ブランチ
feature

## 変更概要
Nuxt4プロジェクトにSupabaseとPiniaを統合してポケモンアプリケーションを構築中

## 発生したエラー
**Error: Cannot access 'renderer$1' before initialization**

### エラー原因
- サーバーサイドのAPIハンドラー (`server/api/secure-pokemon.get.ts`) で `useNuxtApp()` を使用したコンポーザブル (`usePokemon`) を呼び出している
- `useNuxtApp()` はクライアントサイドでのみ利用可能だが、サーバーサイドで実行しようとしてエラー発生

## ファイル変更内容

### 変更されたファイル:
1. **app/app.vue**
   - `<NuxtWelcome />` を削除
   - `<NuxtPage />` に変更してルーティング対応

2. **nuxt.config.ts**
   - `@pinia/nuxt` モジュール追加
   - Supabase環境変数設定 (`supabaseUrl`, `supabaseAnonKey`)

3. **package.json**
   - 依存関係追加:
     - `@pinia/nuxt: ^0.11.2`
     - `@supabase/supabase-js: ^2.56.1`
     - `pinia: ^3.0.3`

### 新規作成されたファイル:
1. **app/composables/useSupaPokemon.ts**
   - Supabase用のコンポーザブル
   - `getAllPokemon()`, `getPokemonById()` 関数
   - `useNuxtApp()` を使用（クライアントサイド専用）

2. **server/api/secure-pokemon.get.ts**
   - サーバーサイドAPIエンドポイント
   - `usePokemon()` を呼び出し（問題の原因）

3. **その他の新規ディレクトリ**
   - `app/pages/` 
   - `app/plugins/`
   - `app/types/`

## 解決が必要な問題
- サーバーサイドAPI用に専用のSupabaseクライアント作成が必要
- `useNuxtApp()` を使わないサーバーサイド用の実装に変更

## 次のステップ
1. サーバーサイドAPIでのSupabase直接接続実装
2. クライアントサイドとサーバーサイドでの適切な責任分離